### PR TITLE
Allow options to be passed to goto of Puppeteer

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,12 +295,16 @@ and then use the HTML of the resulting page.
 
 Use the `browser` kind in the configuration and the `navigate` key to set the
 URL to retrieve. note that the normal `url` job keys are not supported
-for the `browser` job types at the moment, for example:
+for the `browser` job types at the moment. Configure the `options` key to pass
+[additional options](https://miyakogi.github.io/pyppeteer/reference.html#pyppeteer.page.Page.goto)
+to Pyppeteer. For example:
 
 ```yaml
 kind: browser
 name: "A Page With JavaScript"
 navigate: http://example.org/
+options:
+  waitUntil: networkidle0
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -295,7 +295,15 @@ and then use the HTML of the resulting page.
 
 Use the `browser` kind in the configuration and the `navigate` key to set the
 URL to retrieve. note that the normal `url` job keys are not supported
-for the `browser` job types at the moment. Configure the `options` key to pass
+for the `browser` job types at the moment, for example:
+
+```yaml
+kind: browser
+name: "A Page With JavaScript"
+navigate: http://example.org/
+```
+
+Configure the optional `options` key to pass
 [additional options](https://miyakogi.github.io/pyppeteer/reference.html#pyppeteer.page.Page.goto)
 to Pyppeteer. For example:
 

--- a/lib/urlwatch/jobs.py
+++ b/lib/urlwatch/jobs.py
@@ -359,6 +359,7 @@ class BrowserJob(Job):
     __kind__ = 'browser'
 
     __required__ = ('navigate',)
+    __optional__ = ('options',)
 
     LOCATION_IS_URL = True
 
@@ -406,7 +407,7 @@ class BrowserJob(Job):
         def _get_content(browser):
             context = yield from browser.createIncognitoBrowserContext()
             page = yield from context.newPage()
-            yield from page.goto(self.navigate)
+            yield from page.goto(self.navigate, options=self.options)
             content = yield from page.content()
             yield from context.close()
             return content


### PR DESCRIPTION
Allow options to be passed to goto of Puppeteer. This is ideal to use options like `waitUntil` for javascript-rendered websites.